### PR TITLE
Streamline some styles

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -4,6 +4,7 @@
 		<title>Contact Me</title>
 		<link rel="icon" type="image/png" href="favicon.png"/>
 		<link href="style.css" rel="stylesheet" type="text/css" />
+		<link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
 	</head>
 	<body>
  		    <div class="options">

--- a/coop.html
+++ b/coop.html
@@ -4,6 +4,7 @@
 		<title>My Co-op Experience</title>
 		<link rel="icon" type="image/png" href="favicon.png"/>
 		<link href="style.css" rel="stylesheet" type="text/css" />
+		<link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
 	</head>
 	
 	<body class="page-body">

--- a/coop.html
+++ b/coop.html
@@ -34,7 +34,7 @@
 		<div class="bod">
 		<h1 id="coop-title">Applications Engineering Coop</h1>
 		<h3>Siemens PLM Software</h3>
-		<a href="./siemens.jpg" target="_blank"><img class="coop-pic" src="siemens.jpg" alt="Other co-ops and me at Siemens PLM Software"/></a>
+		<a href="./siemens.jpg" target="_blank"><img class="article-pic" src="siemens.jpg" alt="Other co-ops and me at Siemens PLM Software"/></a>
 		<div class="coop-body">
 		<p>My first co-op rotation was spent learning how to use Siemens’ CAD software, NX, and understanding the expected behavior of its Drafting-specific tools. I spent a lot of time manually testing the software for bugs. The main aspect of my job was recording autotests to test regression scenarios. This basically meant recording a session of NX in which I manually followed a series of steps which produced an error in a previous version of NX. Then, upon each new release of NX, my tests would be played back to make sure that the error did not occur again. I gained a firm grasp on how to use CAD software to model 3D objects and how to translate those models to 2D drawings.</p>
 		 

--- a/exploringleadership.html
+++ b/exploringleadership.html
@@ -4,6 +4,7 @@
 		<title>My Leadership Seminar</title>
 		<link rel="icon" type="image/png" href="favicon.png"/>
 		<link href="style.css" rel="stylesheet" type="text/css" />
+		<link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
 	</head>
 	<body class="page-body">
 		 <div class="options">

--- a/gateway.html
+++ b/gateway.html
@@ -4,6 +4,7 @@
 		<title>Gateway to University Honors</title>
 		<link rel="icon" type="image/png" href="favicon.png"/>
 		<link href="style.css" rel="stylesheet" type="text/css" />
+		<link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
 	</head>
 	<body class="page-body">
  	        <div class="options">

--- a/hackathon.html
+++ b/hackathon.html
@@ -32,7 +32,7 @@
     		    </div>
 		<div class="bod">
 		<h1>Hackathon Organizer</h1>
-		<a href="./organizer.jpg"><img class="organizer-pic" src="organizer.jpg" alt="Image of the other organizers and me"/></a>
+		<a href="./organizer.jpg"><img class="article-pic" src="organizer.jpg" alt="Image of the other organizers and me"/></a>
 		<div class="coop-body">
 		<p>During the fall of 2016 I was on the organizing team for RevolutionUC, the University of Cincinnati's student-run hackathon. For anyone who might not know what a hackathon is, it is a chance for students everywhere to get together and make something. They are typically 24 hour events in which students form teams, come up with a "hack," and build a working prototype to demo to judges. RevolutionUC is completely free for students, and we provide snacks, meals, swag, and prizes. This of course requires funding, mainly through corporate sponsorship, which is where I fit in.</p>
 		<p>I was on the sponsorship committee with two other organizers, and our goal was to raise $12,000 for this event. Between the three of us, we ended up raising $21,000, nearly doubling our goal. My job was to reach out to contacts at various companies and describe what RevolutionUC is and what hackathons are, and ask if they'd like to get involved. I was their contact for all monetary questions and questions about the benefits of sponsorship and most day-of details.</p>

--- a/hackathon.html
+++ b/hackathon.html
@@ -4,6 +4,7 @@
 		<title>Hackathon Organizer</title>
 		<link rel="icon" type="image/png" href="favicon.png"/>
 		<link href="style.css" rel="stylesheet" type="text/css" />
+		<link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
 	</head>
 	<body class="page-body">
 		    <div class="options">

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 		<title>Laura Tebben</title>
 		<link rel="icon" type="image/png" href="favicon.png"/>
 		<link rel="stylesheet" type="text/css" href="style.css">
-		<link href="https://fonts.googleapis.com/css?family=Alfa+Slab+One" rel="stylesheet">
+		<link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
 	</head>
     <body class="page-body">
     <div class="options">

--- a/paris.html
+++ b/paris.html
@@ -4,6 +4,7 @@
 		<title>My Paris Trip</title>
 		<link rel="icon" type="image/png" href="favicon.png"/>
 		<link href="style.css" rel="stylesheet" type="text/css" />
+		<link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
 	</head>
 	<body class="page-body">
 	         <div class="options">

--- a/projects.html
+++ b/projects.html
@@ -4,6 +4,7 @@
 		<title>My Personal Projects</title>
 		<link rel="icon" type="image/png" href="favicon.png"/>
 		<link href="style.css" rel="stylesheet" type="text/css" />
+		<link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
 	</head>
 	<body class="page-body">
 		    <div class="options">

--- a/style.css
+++ b/style.css
@@ -119,13 +119,11 @@ h1 {
 	margin-bottom: 30px;
 }
 
-.coop-pic {
+.article-pic {
 	width: 400px;
 	max-width: 50%;
-	display: inline-block;
 	float: right;
 	shape-outside: content-box;
-	-webkit-clip-path: content-box;
 	margin-top: 40px;
 }
 
@@ -135,17 +133,6 @@ h1 {
 
 .pdf {
 	max-width: 100%;
-}
-
-.organizer-pic {
-	width: 400px;
-	max-width: 50%;
-	display: inline-block;
-	float: right;
-	shape-outside: content-box;
-	-webkit-clip-path: content-box;
-	margin-top: 5px;
-
 }
 
 .options {

--- a/style.css
+++ b/style.css
@@ -9,7 +9,6 @@
 
 #name {
 	font-size: 50px;
-	font-family: 'Open Sans';
 	letter-spacing: 3px;
 	word-spacing: 5px;
 	color: black;

--- a/ta.html
+++ b/ta.html
@@ -4,6 +4,7 @@
 		<title>My TA experience</title>
 		<link rel="icon" type="image/png" href="favicon.png"/>
 		<link href="style.css" rel="stylesheet" type="text/css" />
+		<link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
 	</head>
 	<body class="page-body">
  		    <div class="options">


### PR DESCRIPTION
1.) Added a request for the Open Sans font since your stylesheet was trying to use it but it was never being pulled in

2.) Turned `.coop-pic` and `.organizer-pic` => `.article-pic` to simplify the styles. They were identical except for one property (`margin-top: 40px` and `margin-top: 5px`). If you still want to maintain this difference you can add another `id` that will overrule the `margin-top` found in the `article-pic` class and add that `id` to one of the pictures. That would still be simpler than duping the styles.

3.) Got rid of `-webkit-clip-path` property because it shouldn't be necessary for your use-case (and chrome does not detect the `content-box` value for that property anyways it seems)

4.) Removed `display: inline-block` on the `.article-pic` class because `float: xxx` takes an element out of the normal flow of the page (allowing us to throw it on the same line as some text etc) therefore all `display` property values are ignored, with the exception of `display: none` which rips an element from the render tree.